### PR TITLE
refactor: update deps in proper order

### DIFF
--- a/lib/update.ts
+++ b/lib/update.ts
@@ -13,12 +13,12 @@ import { getPackageJson } from "./project-helpers";
 export async function update({ updateWebpack, updateAngularDeps }) {
     await addNpmScripts({ updateWebpack, updateAngularDeps });
 
-    if (updateWebpack) {
-        await updateNsWebpack(updateWebpack);
-    }
-
     if (updateAngularDeps) {
         await updateNg();
+    }
+
+    if (updateWebpack) {
+        await updateNsWebpack(updateWebpack);
     }
 }
 


### PR DESCRIPTION
The proper order is to:
1. update angular deps - this would take the version of `@angular/core`, etc. from the `nativescript-angular` plugin and bring it to the app,
2. update webpack deps - this would take the version of `@angular/core`, etc. from the app and use it for `@angular/compiler-cli`.