### PR TITLE
refactor(configs): bump chunk sizes for {N} 3.4

### DIFF
--- a/configs/hello-world-ng/verify.config.json
+++ b/configs/hello-world-ng/verify.config.json
@@ -230,7 +230,7 @@
                     ],
                     "outputSizes": {
                         "bundle.js": "1400000",
-                        "vendor.js": "3600000"
+                        "vendor.js": "3650000"
                     }
                 },
                 {

--- a/configs/hello-world-ts/verify.config.json
+++ b/configs/hello-world-ts/verify.config.json
@@ -279,7 +279,7 @@
                     ],
                     "outputSizes": {
                         "bundle.js": "9300",
-                        "vendor.js": "1400000"
+                        "vendor.js": "1450000"
                     }
                 },
                 {

--- a/configs/hello-world/verify.config.json
+++ b/configs/hello-world/verify.config.json
@@ -244,7 +244,7 @@
                     ],
                     "outputSizes": {
                         "bundle.js": "8000",
-                        "vendor.js": "1400000"
+                        "vendor.js": "1450000"
                     }
                 },
                 {


### PR DESCRIPTION
tns-core-modules 3.4+ are slightly bigger which affects app sizes when
bundling without uglify (and without tree-shaking).