### PR TITLE
chore: remove updating of deps for webpack demo apps

### DIFF
--- a/configs/AngularApp/verify.config.json
+++ b/configs/AngularApp/verify.config.json
@@ -6,26 +6,6 @@
             "name": "android",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-angular",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-typescript",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "android",
                     "package": "next",
                     "type": "nsPlatform"
@@ -37,36 +17,12 @@
             "name": "ios",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-angular",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-typescript",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "ios",
                     "package": "next",
                     "type": "nsPlatform"
                 }
             ],
-            "updateAngularDeps": true,
-            "updateWebpack": {
-                "configs": true,
-                "deps": true
-            }
+            "updateAngularDeps": true
         },
         {
             "name": "latest",

--- a/configs/JavaScriptApp/verify.config.json
+++ b/configs/JavaScriptApp/verify.config.json
@@ -7,49 +7,21 @@
             "name": "android",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "android",
                     "package": "next",
                     "type": "nsPlatform"
                 }
-            ],
-            "updateWebpack": {
-                "configs": true,
-                "deps": true
-            }
+            ]
         },
         {
             "name": "ios",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "ios",
                     "package": "next",
                     "type": "nsPlatform"
                 }
-            ],
-            "updateWebpack": {
-                "configs": true,
-                "deps": true
-            }
+            ]
         },
         {
             "name": "latest",

--- a/configs/TypeScriptApp/verify.config.json
+++ b/configs/TypeScriptApp/verify.config.json
@@ -7,59 +7,21 @@
             "name": "android",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-typescript",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "android",
                     "package": "next",
                     "type": "nsPlatform"
                 }
-            ],
-            "updateWebpack": {
-                "configs": true,
-                "deps": true
-            }
+            ]
         },
         {
             "name": "ios",
             "dependencies": [
                 {
-                    "name": "tns-core-modules",
-                    "package": "next",
-                    "type": "dependency"
-                },
-                {
-                    "name": "nativescript-dev-typescript",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
-                    "name": "nativescript-dev-webpack",
-                    "package": "next",
-                    "type": "devDependency"
-                },
-                {
                     "name": "ios",
                     "package": "next",
                     "type": "nsPlatform"
                 }
-            ],
-            "updateWebpack": {
-                "configs": true,
-                "deps": true
-            }
+            ]
         },
         {
             "name": "latest",


### PR DESCRIPTION
They are already targeting latest/rc in the repo